### PR TITLE
Add rowDataGetter to Table component.

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -196,6 +196,13 @@ var FixedDataTable = createReactClass({
     rowKeyGetter: PropTypes.func,
 
     /**
+     * If specified, `rowDataGetter(index)` is called for each row and the
+     * returned value will be accessible in each cell of that row through the
+     * `rowData` prop.
+     */
+    rowDataGetter: PropTypes.func,
+
+    /**
      * Pixel height of the column group header.
      */
     groupHeaderHeight: PropTypes.number,
@@ -685,6 +692,7 @@ var FixedDataTable = createReactClass({
         rowGetter={state.rowGetter}
         rowHeightGetter={state.rowHeightGetter}
         rowKeyGetter={state.rowKeyGetter}
+        rowDataGetter={state.rowDataGetter}
         scrollLeft={state.scrollX}
         scrollableColumns={state.bodyScrollableColumns}
         showLastRowBorder={true}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -41,6 +41,7 @@ var FixedDataTableBufferedRows = createReactClass({
     rowsCount: PropTypes.number.isRequired,
     rowHeightGetter: PropTypes.func,
     rowKeyGetter: PropTypes.func,
+    rowDataGetter: PropTypes.func,
     rowPositionGetter: PropTypes.func.isRequired,
     scrollLeft: PropTypes.number.isRequired,
     scrollableColumns: PropTypes.array.isRequired,
@@ -143,6 +144,7 @@ var FixedDataTableBufferedRows = createReactClass({
       var currentRowHeight = this._getRowHeight(rowIndex);
       var rowOffsetTop = baseOffsetTop + rowPositions[rowIndex];
       var rowKey = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : i;
+      var rowData = props.rowDataGetter ? props.rowDataGetter(rowIndex) : undefined;
 
       var hasBottomBorder =
         rowIndex === props.rowsCount - 1 && props.showLastRowBorder;
@@ -152,6 +154,7 @@ var FixedDataTableBufferedRows = createReactClass({
           key={rowKey}
           isScrolling={props.isScrolling}
           index={rowIndex}
+          data={rowData}
           width={props.width}
           height={currentRowHeight}
           scrollLeft={Math.round(props.scrollLeft)}

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -62,6 +62,12 @@ var FixedDataTableCell = createReactClass({
     rowIndex: PropTypes.number.isRequired,
 
     /**
+     * The data associated with the current row that will be passed to 
+     * `cellRenderer` to render.
+     */
+    rowData: PropTypes.object,
+
+    /**
      * Callback for when resizer knob (in FixedDataTableCell) is clicked
      * to initialize resizing. Please note this is only on the cells
      * in the header.
@@ -202,7 +208,7 @@ var FixedDataTableCell = createReactClass({
 
   render() /*object*/ {
 
-    var {height, width, columnKey, ...props} = this.props;
+    var {height, width, columnKey, rowData, ...props} = this.props;
 
     var style = {
       height,
@@ -271,7 +277,8 @@ var FixedDataTableCell = createReactClass({
     var cellProps = {
       columnKey,
       height,
-      width
+      width,
+      rowData
     };
 
     if (props.rowIndex >= 0) {

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -52,6 +52,8 @@ var FixedDataTableCellGroupImpl = createReactClass({
 
     rowIndex: PropTypes.number.isRequired,
 
+    rowData: PropTypes.object,
+
     width: PropTypes.number.isRequired,
 
     zIndex: PropTypes.number.isRequired,
@@ -86,6 +88,7 @@ var FixedDataTableCellGroupImpl = createReactClass({
         var key = columnProps.columnKey || 'cell_' + i;
         cells[i] = this._renderCell(
           props.rowIndex,
+          props.rowData,
           props.rowHeight,
           columnProps,
           currentPosition,
@@ -115,6 +118,7 @@ var FixedDataTableCellGroupImpl = createReactClass({
 
   _renderCell(
     /*number*/ rowIndex,
+    /*object*/ rowData,
     /*number*/ height,
     /*object*/ columnProps,
     /*number*/ left,
@@ -149,6 +153,7 @@ var FixedDataTableCellGroupImpl = createReactClass({
         isColumnReordering={isColumnReordering}
         columnReorderingData={this.props.columnReorderingData}
         rowIndex={rowIndex}
+        rowData={rowData}
         columnKey={columnProps.columnKey}
         width={columnProps.width}
         left={left}
@@ -193,6 +198,7 @@ var FixedDataTableCellGroup = createReactClass({
     zIndex: PropTypes.number.isRequired,
   },
 
+  // NOTE: Should we check if rowData has changed?
   shouldComponentUpdate(/*object*/ nextProps) /*boolean*/ {
     return (
       !nextProps.isScrolling ||

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -198,7 +198,6 @@ var FixedDataTableCellGroup = createReactClass({
     zIndex: PropTypes.number.isRequired,
   },
 
-  // NOTE: Should we check if rowData has changed?
   shouldComponentUpdate(/*object*/ nextProps) /*boolean*/ {
     return (
       !nextProps.isScrolling ||

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -46,6 +46,11 @@ class FixedDataTableRowImpl extends React.Component {
     index: PropTypes.number.isRequired,
 
     /**
+     * Data associated with the row.
+     */
+    data: PropTypes.object,
+
+    /**
      * Array of <FixedDataTableColumn /> for the scrollable columns.
      */
     scrollableColumns: PropTypes.array.isRequired,
@@ -139,6 +144,7 @@ class FixedDataTableRowImpl extends React.Component {
         columnReorderingData={this.props.columnReorderingData}
         rowHeight={this.props.height}
         rowIndex={this.props.index}
+        rowData={this.props.data}
       />;
     var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
     var scrollableColumns =
@@ -159,6 +165,7 @@ class FixedDataTableRowImpl extends React.Component {
         columnReorderingData={this.props.columnReorderingData}
         rowHeight={this.props.height}
         rowIndex={this.props.index}
+        rowData={this.props.data}
       />;
     var scrollableColumnsWidth = this._getColumnsWidth(this.props.scrollableColumns);
     var columnsRightShadow = this._renderColumnsRightShadow(fixedColumnsWidth + scrollableColumnsWidth);


### PR DESCRIPTION
Enables the consumer of `Table` to receive custom data across all cells of an associated row. This data is the result of the `rowDataGetter(rowIndex)` callback, and can be accessed through the `rowData` prop inside a cell.